### PR TITLE
Xss

### DIFF
--- a/FluentBootstrap.Tests.Web/Views/Tests/Tags.cshtml
+++ b/FluentBootstrap.Tests.Web/Views/Tests/Tags.cshtml
@@ -38,5 +38,13 @@
     using (Html.Bootstrap().Div().SetId("test-add-child").Begin())
     {
         @Html.Bootstrap().GridRow().AddChild(x => x.GridColumn(6).AddContent("A")).AddChild(x => x.GridColumn(6).AddContent("B").AddChild(y => Html.Bootstrap().Container()))
+    }    
+    
+    <hr />
+
+    @Html.Bootstrap().Heading1("AddContent adds a component")
+    using (Html.Bootstrap().Div().SetId("test-addcontent-adds-component").Begin())
+    {
+        @Html.Bootstrap().Div().AddContent(Html.Bootstrap().Span("span-component"))
     }
 }

--- a/FluentBootstrap.Tests.Web/Views/Tests/Tags.cshtml
+++ b/FluentBootstrap.Tests.Web/Views/Tests/Tags.cshtml
@@ -47,4 +47,12 @@
     {
         @Html.Bootstrap().Div().AddContent(Html.Bootstrap().Span("span-component"))
     }
+    
+    <hr />
+
+    @Html.Bootstrap().Heading1("AddContentAtEnd adds a component")
+    using (Html.Bootstrap().Div().SetId("test-addcontentatend-adds-component").Begin())
+    {
+        @Html.Bootstrap().Div().AddContentAtEnd(Html.Bootstrap().Span("span-component1")).AddContentAtEnd(Html.Bootstrap().Span("span-component2"))
+    }
 }

--- a/FluentBootstrap.Tests/TagsFixture.cs
+++ b/FluentBootstrap.Tests/TagsFixture.cs
@@ -61,5 +61,14 @@ namespace FluentBootstrap.Tests
 @"<div>
   <span>span-component</span></div>");
         }
+
+        [Test]
+        public void AddContentAtEndWithComponentProducesCorrectHtml()
+        {
+            TestHelper.AssertHtml<ASP._Views_Tests_Tags_cshtml>("test-addcontentatend-adds-component",
+@"<div>
+  <span>span-component1</span>
+  <span>span-component2</span></div>");
+        }
     }
 }

--- a/FluentBootstrap.Tests/TagsFixture.cs
+++ b/FluentBootstrap.Tests/TagsFixture.cs
@@ -53,5 +53,13 @@ namespace FluentBootstrap.Tests
    </div>
   </div>");
         }
+
+        [Test]
+        public void AddContentWithComponentProducesCorrectHtml()
+        {
+            TestHelper.AssertHtml<ASP._Views_Tests_Tags_cshtml>("test-addcontent-adds-component",
+@"<div>
+  <span>span-component</span></div>");
+        }
     }
 }

--- a/FluentBootstrap/ContentExtensions.cs
+++ b/FluentBootstrap/ContentExtensions.cs
@@ -8,11 +8,12 @@ namespace FluentBootstrap
 {
     public static class ContentExtensions
     {
-        public static ComponentBuilder<TConfig, Content> Content<TConfig, TComponent>(this BootstrapHelper<TConfig, TComponent> helper, string content)
+        public static ComponentBuilder<TConfig, Content> Content<TConfig, TComponent>(this BootstrapHelper<TConfig, TComponent> helper, string content, bool isEncoded = false)
             where TConfig : BootstrapConfig
             where TComponent : Component, ICanCreate<Content>
         {
-            content = HttpUtility.HtmlEncode(content);
+            if (!isEncoded)
+                content = HttpUtility.HtmlEncode(content);
             return new ComponentBuilder<TConfig, Content>(helper.Config, new Content(helper, content));
         }
 

--- a/FluentBootstrap/TagExtensions.cs
+++ b/FluentBootstrap/TagExtensions.cs
@@ -83,7 +83,7 @@ namespace FluentBootstrap
         }
 
         public static ComponentBuilder<TConfig, TTag> AddContent<TConfig, TTag>(this ComponentBuilder<TConfig, TTag> builder, object content)
-            where TConfig : BootstrapConfig 
+            where TConfig : BootstrapConfig
             where TTag : Tag
         {
             if (content != null)
@@ -100,7 +100,11 @@ namespace FluentBootstrap
                 IHtmlString htmlString = content as IHtmlString;
                 if (htmlString != null)
                 {
+                    //component.ToHtmlString() sets _startet = true, so the next .ToHtmlString() call will be a empty result
+                    //so we can't pass the htmlString to .Content()
                     str = htmlString.ToHtmlString();
+                    if (!string.IsNullOrEmpty(str))
+                        builder.Component.AddChild(builder.GetHelper().Content(str, isEncoded: true));
                 }
                 else
                 {
@@ -108,11 +112,8 @@ namespace FluentBootstrap
                     str = Convert.ToString(content, CultureInfo.InvariantCulture);
                     str = HttpUtility.HtmlEncode(str);
                     htmlString = new HtmlString(str);
-                }
-
-                if (!string.IsNullOrEmpty(str))
-                {
-                    builder.Component.AddChild(builder.GetHelper().Content(htmlString));
+                    if (!string.IsNullOrEmpty(str))
+                        builder.Component.AddChild(builder.GetHelper().Content(htmlString));
                 }
             }
             return builder;

--- a/FluentBootstrap/TagExtensions.cs
+++ b/FluentBootstrap/TagExtensions.cs
@@ -137,17 +137,20 @@ namespace FluentBootstrap
                 IHtmlString htmlString = content as IHtmlString;
                 if (htmlString != null)
                 {
+                    //component.ToHtmlString() sets _startet = true, so the next .ToHtmlString() call will be a empty result
+                    //so we can't pass the htmlString to .Content()
                     str = htmlString.ToHtmlString();
+                    if (!string.IsNullOrEmpty(str))
+                        builder.Component.AddChildAtEnd(builder.GetHelper().Content(str, isEncoded: true));
                 }
                 else
                 {
                     // Just convert to a string using the standard conversion logic
                     str = Convert.ToString(content, CultureInfo.InvariantCulture);
-                }
-
-                if (!string.IsNullOrEmpty(str))
-                {
-                    builder.Component.AddChildAtEnd(builder.GetHelper().Content(str));
+                    str = HttpUtility.HtmlEncode(str);
+                    htmlString = new HtmlString(str);
+                    if (!string.IsNullOrEmpty(str))
+                        builder.Component.AddChildAtEnd(builder.GetHelper().Content(htmlString));
                 }
             }
             return builder;


### PR DESCRIPTION
`TagExtensions.AddContent() `does not work properly. When a component is passed into this method, the call to `component.ToHtmlString()` sets the `_started `property within this component internally.
So all subsequent calls to `component.ToHtmlString()` (like in the `Content()` extension) do not deliver any string result any more. So the rendered result does not include the child component.

In addition I've adapted the "prevent XSS" changes to the method `TagExtensions.AddContentAtEnd().
`
